### PR TITLE
Use the provided index name for primary keys

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/SQLServerPlatform.php
@@ -338,7 +338,7 @@ SQL
             $identifier = $table;
         }
 
-        $sql = 'ALTER TABLE ' . $identifier . ' ADD PRIMARY KEY';
+        $sql = 'ALTER TABLE ' . $identifier . ' ADD CONSTRAINT ' . $index->getQuotedName($this) . ' PRIMARY KEY';
 
         if ($index->hasFlag('nonclustered')) {
             $sql .= ' NONCLUSTERED';


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

If an index name is passed in setPrimaryKey(), it's not used by the SQL Server platform class and one generated by the database instead. This makes it impossible to specify the required key name when creating a full text column.
